### PR TITLE
ci(web): exit relax mode (remove continue-on-error)

### DIFF
--- a/.github/workflows/ci_web.yml
+++ b/.github/workflows/ci_web.yml
@@ -17,7 +17,7 @@ jobs:
   web:
     name: Web (Nuxt 4 / Tailwind 4)
     runs-on: ubuntu-latest
-    continue-on-error: true
+
     defaults:
       run:
         working-directory: frontend

--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+"""
+Basic DRF tests for Project CRUD and permissions.
+
+Covers:
+- Anonymous access is denied (401)
+- Authenticated owner can create/list/retrieve/update/delete their projects
+- Non-owner cannot access another user's project (404 due to queryset scoping)
+- Admin can access any project
+- Custom action /api/v1/projects/mine/ returns only the caller's projects
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Callable, Tuple
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_anonymous_cannot_access_projects_list() -> None:
+    client = APIClient()
+    url = reverse("project-list")  # /api/v1/projects/
+    resp = client.get(url)
+    assert resp.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+
+
+@pytest.fixture()
+def make_user(db) -> Callable[[str, bool], User]:
+    def _mk(username: str, is_superuser: bool = False) -> User:
+        u = User.objects.create_user(username=username, password="test-pass")
+        if is_superuser:
+            u.is_superuser = True
+            u.is_staff = True
+            u.save(update_fields=["is_superuser", "is_staff"])
+        return u
+
+    return _mk
+
+
+def _auth_client(user: User) -> APIClient:
+    c = APIClient()
+    c.force_authenticate(user=user)
+    return c
+
+
+def _create_project(client: APIClient, name: str = "Alpha", **extra) -> Tuple[dict, str]:
+    """
+    Create a project via API and return (json_response, slug).
+    """
+    url = reverse("project-list")
+    payload = {"name": name, "description": extra.get("description", ""), "status": "draft"}
+    resp = client.post(url, data=json.dumps(payload), content_type="application/json")
+    assert resp.status_code == status.HTTP_201_CREATED, resp.content
+    data = resp.json()
+    assert "id" in data and "slug" in data and data["owner"] is not None
+    return data, data["slug"]
+
+
+@pytest.mark.django_db
+def test_owner_can_create_project_and_is_owner(make_user) -> None:
+    owner = make_user("owner1")
+    client = _auth_client(owner)
+
+    data, slug = _create_project(client, name="Site Vitrine")
+    assert data["name"] == "Site Vitrine"
+    assert data["owner"] == owner.pk
+    assert isinstance(slug, str) and len(slug) > 0
+
+    # retrieve by slug
+    detail = reverse("project-detail", kwargs={"slug": slug})
+    resp = client.get(detail)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["slug"] == slug
+
+
+@pytest.mark.django_db
+def test_mine_lists_only_own_projects(make_user) -> None:
+    owner = make_user("owner1")
+    other = make_user("other1")
+
+    client_owner = _auth_client(owner)
+    client_other = _auth_client(other)
+
+    # Each creates a project
+    _, slug_owner = _create_project(client_owner, name="Owner Project")
+    _, slug_other = _create_project(client_other, name="Other Project")
+
+    # /api/v1/projects/mine/ should return only the caller's projects
+    mine_url = reverse("project-mine")
+    resp_owner = client_owner.get(mine_url)
+    resp_other = client_other.get(mine_url)
+
+    assert resp_owner.status_code == status.HTTP_200_OK
+    assert resp_other.status_code == status.HTTP_200_OK
+
+    owner_slugs = {p["slug"] for p in resp_owner.json()}
+    other_slugs = {p["slug"] for p in resp_other.json()}
+
+    assert slug_owner in owner_slugs
+    assert slug_other not in owner_slugs
+
+    assert slug_other in other_slugs
+    assert slug_owner not in other_slugs
+
+
+@pytest.mark.django_db
+def test_non_owner_cannot_access_others_project(make_user) -> None:
+    owner = make_user("owner1")
+    intruder = make_user("intruder")
+
+    client_owner = _auth_client(owner)
+    client_intruder = _auth_client(intruder)
+
+    _, slug = _create_project(client_owner, name="Owner Only")
+
+    # Intruder attempts to GET detail → 404 (scoped queryset hides it)
+    detail = reverse("project-detail", kwargs={"slug": slug})
+    resp = client_intruder.get(detail)
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    # Intruder attempts to PATCH → also 404
+    resp = client_intruder.patch(
+        detail,
+        data=json.dumps({"description": "hacked?"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    # Intruder attempts to DELETE → 404
+    resp = client_intruder.delete(detail)
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+def test_admin_can_access_any_project(make_user) -> None:
+    owner = make_user("owner1")
+    admin = make_user("admin1", is_superuser=True)
+
+    client_owner = _auth_client(owner)
+    client_admin = _auth_client(admin)
+
+    _, slug = _create_project(client_owner, name="Owner Project")
+    detail = reverse("project-detail", kwargs={"slug": slug})
+
+    # Admin GET
+    resp = client_admin.get(detail)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["slug"] == slug
+
+    # Admin PATCH
+    resp = client_admin.patch(
+        detail,
+        data=json.dumps({"status": "active"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["status"] == "active"
+
+    # Admin DELETE
+    resp = client_admin.delete(detail)
+    assert resp.status_code == status.HTTP_204_NO_CONTENT
+
+
+@pytest.mark.django_db
+def test_owner_update_and_delete_flow(make_user) -> None:
+    owner = make_user("owner1")
+    client = _auth_client(owner)
+
+    data, slug = _create_project(client, name="Initial")
+    detail = reverse("project-detail", kwargs={"slug": slug})
+
+    # Update description and status
+    resp = client.patch(
+        detail,
+        data=json.dumps({"description": "New desc", "status": "active"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    body = resp.json()
+    assert body["description"] == "New desc"
+    assert body["status"] == "active"
+
+    # Delete
+    resp = client.delete(detail)
+    assert resp.status_code == status.HTTP_204_NO_CONTENT
+
+    # Ensure it's gone
+    resp = client.get(detail)
+    assert resp.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/studio_core/settings/base.py
+++ b/backend/studio_core/settings/base.py
@@ -140,6 +140,7 @@ REST_FRAMEWORK = {
         "rest_framework.permissions.IsAuthenticated",
     ],
     "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.SessionAuthentication",
         "rest_framework_simplejwt.authentication.JWTAuthentication",
     ],
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",

--- a/backend/studio_core/settings/base.py
+++ b/backend/studio_core/settings/base.py
@@ -105,6 +105,7 @@ INSTALLED_APPS = [
     "accounts.apps.AccountsConfig",
     "ai_assistants.apps.AiAssistantsConfig",  # ← AJOUT
     "overall_context",  # ← (optionnel) si tu l’emploies
+    "api",
 ]
 
 # Optionally include API app skeleton if present (safe import)
@@ -133,6 +134,16 @@ try:
 except Exception:
     _HAS_RATELIMIT = False
 
+# DRF — OpenAPI schema via drf-spectacular
+REST_FRAMEWORK = {
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.IsAuthenticated",
+    ],
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
+    ],
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+}
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",

--- a/frontend/app/pages/projects/[slug].vue
+++ b/frontend/app/pages/projects/[slug].vue
@@ -1,0 +1,155 @@
+<template>
+  <section class="mx-auto max-w-3xl p-6 space-y-6">
+    <header class="flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <NuxtLink to="/projects" class="text-sm text-blue-600 hover:underline">← Back</NuxtLink>
+        <h1 class="text-2xl font-semibold">Project: {{ project?.name ?? slug }}</h1>
+      </div>
+      <button
+        class="btn bg-red-600 hover:bg-red-700"
+        @click="onDelete"
+        :disabled="deleting || pending"
+        title="Delete project"
+      >
+        Delete
+      </button>
+    </header>
+
+    <div v-if="pending" class="text-gray-600">Loading…</div>
+    <div v-else-if="loadError" class="text-red-700">
+      Failed to load project: {{ loadError }}
+    </div>
+    <div v-else-if="!project" class="text-gray-600">
+      Project not found.
+    </div>
+
+    <form v-else @submit.prevent="onSave" class="space-y-4 border rounded p-4">
+      <div>
+        <label class="block text-sm font-medium mb-1">Name</label>
+        <input
+          v-model="form.name"
+          type="text"
+          class="input"
+          placeholder="Project name"
+          :disabled="saving"
+        />
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium mb-1">Description</label>
+        <textarea
+          v-model="form.description"
+          class="input"
+          placeholder="Short description (optional)"
+          :disabled="saving"
+        />
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium mb-1">Status</label>
+        <select v-model="form.status" class="input" :disabled="saving">
+          <option value="draft">draft</option>
+          <option value="active">active</option>
+          <option value="archived">archived</option>
+        </select>
+      </div>
+
+      <div class="text-xs text-gray-500">
+        <div><span class="font-medium">Updated:</span> {{ formatDate(project.updated_at) }}</div>
+        <div><span class="font-medium">Created:</span> {{ formatDate(project.created_at) }}</div>
+      </div>
+
+      <div class="flex items-center gap-3">
+        <button class="btn" :disabled="saving || pending">Save</button>
+        <span v-if="err" class="text-red-600 text-sm">{{ err }}</span>
+        <span v-if="ok" class="text-green-600 text-sm">Saved</span>
+      </div>
+    </form>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watchEffect } from 'vue'
+import type { Project, ProjectUpdateBody } from '~/shared/types/projects'
+
+const route = useRoute()
+const slug = computed(() => route.params.slug as string)
+
+const {
+  data,
+  pending,
+  refresh,
+  error: loadErr,
+} = await useFetch<Project>(`/api/projects/${slug.value}`, { method: 'GET' })
+
+const project = computed<Project | null>(() => data.value || null)
+const loadError = computed(() => (loadErr.value ? (loadErr.value as any)?.statusMessage ?? 'Unknown error' : null))
+
+const form = ref<ProjectUpdateBody>({
+  name: '',
+  description: '',
+  status: 'draft',
+})
+
+watchEffect(() => {
+  if (project.value) {
+    form.value = {
+      name: project.value.name,
+      description: project.value.description,
+      status: project.value.status,
+    }
+  }
+})
+
+const saving = ref(false)
+const deleting = ref(false)
+const err = ref<string | null>(null)
+const ok = ref(false)
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString()
+  } catch {
+    return iso
+  }
+}
+
+const onSave = async () => {
+  if (!slug.value) return
+  err.value = null
+  ok.value = false
+  saving.value = true
+  try {
+    await $fetch(`/api/projects/${slug.value}`, {
+      method: 'PATCH',
+      body: form.value,
+    })
+    ok.value = true
+    await refresh()
+  } catch (e: any) {
+    err.value = e?.statusMessage || 'Save failed'
+  } finally {
+    saving.value = false
+  }
+}
+
+const onDelete = async () => {
+  if (!slug.value) return
+  if (!confirm('Are you sure you want to delete this project? This action cannot be undone.')) return
+  deleting.value = true
+  err.value = null
+  try {
+    await $fetch(`/api/projects/${slug.value}`, { method: 'DELETE' })
+    await navigateTo('/projects')
+  } catch (e: any) {
+    err.value = e?.statusMessage || 'Delete failed'
+  } finally {
+    deleting.value = false
+  }
+}
+</script>
+
+<style scoped>
+.input { @apply w-full border rounded px-2 py-1 outline-none focus:ring-2 focus:ring-blue-200; }
+.btn { @apply inline-flex items-center px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50; }
+</style>

--- a/frontend/app/pages/projects/index.vue
+++ b/frontend/app/pages/projects/index.vue
@@ -1,0 +1,118 @@
+<template>
+  <section class="mx-auto max-w-4xl p-6 space-y-6">
+    <header class="flex items-center justify-between">
+      <h1 class="text-2xl font-semibold">Projects</h1>
+      <NuxtLink to="/" class="text-sm text-blue-600 hover:underline">Back to Home</NuxtLink>
+    </header>
+
+    <!-- Create Project -->
+    <form @submit.prevent="onCreate" class="space-y-3 border rounded p-4">
+      <h2 class="text-lg font-medium">Create a new project</h2>
+
+      <div>
+        <label class="block text-sm font-medium mb-1">Name</label>
+        <input v-model="form.name" type="text" class="input" placeholder="Ex: Site Vitrine" required />
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium mb-1">Description</label>
+        <textarea v-model="form.description" class="input" placeholder="Optional short description" />
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium mb-1">Status</label>
+        <select v-model="form.status" class="input">
+          <option value="draft">draft</option>
+          <option value="active">active</option>
+          <option value="archived">archived</option>
+        </select>
+      </div>
+
+      <div class="flex items-center gap-3">
+        <button class="btn" :disabled="creating">Create</button>
+        <span v-if="err" class="text-red-600 text-sm">{{ err }}</span>
+        <span v-if="ok" class="text-green-600 text-sm">Created</span>
+      </div>
+    </form>
+
+    <!-- List Projects -->
+    <div class="space-y-2">
+      <div v-if="pending">Loading projects…</div>
+      <div v-else-if="fetchError" class="text-red-700">Failed to load: {{ fetchError }}</div>
+      <ul v-else class="divide-y">
+        <li v-for="p in projects" :key="p.slug" class="py-3 flex items-center justify-between">
+          <div class="min-w-0">
+            <NuxtLink :to="`/projects/${p.slug}`" class="text-blue-600 hover:underline break-words">
+              {{ p.name }}
+            </NuxtLink>
+            <div class="text-xs text-gray-500 mt-0.5">
+              Status: <span class="font-medium">{{ p.status }}</span>
+            </div>
+          </div>
+          <div class="text-xs text-gray-400 shrink-0 ml-3">
+            {{ formatDate(p.updated_at) }}
+          </div>
+        </li>
+      </ul>
+      <div v-if="!pending && projects.length === 0" class="text-sm text-gray-500">No projects yet.</div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import type { Project, ProjectCreateBody } from '~/shared/types/projects'
+
+const {
+  data,
+  pending,
+  refresh,
+  error: loadErr,
+} = await useFetch<Project[]>('/api/projects', { method: 'GET' })
+
+const projects = computed<Project[]>(() => data.value || [])
+const fetchError = computed(() => loadErr.value ? (loadErr.value as any)?.statusMessage ?? 'Unknown error' : null)
+
+const form = ref<ProjectCreateBody>({
+  name: '',
+  description: '',
+  status: 'draft',
+})
+
+const creating = ref(false)
+const err = ref<string | null>(null)
+const ok = ref(false)
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString()
+  } catch {
+    return iso
+  }
+}
+
+const onCreate = async () => {
+  err.value = null
+  ok.value = false
+  creating.value = true
+  try {
+    await $fetch('/api/projects', {
+      method: 'POST',
+      body: form.value,
+    })
+    // Reset form
+    form.value = { name: '', description: '', status: 'draft' }
+    ok.value = true
+    await refresh()
+  } catch (e: any) {
+    err.value = e?.statusMessage || 'Create failed'
+  } finally {
+    creating.value = false
+  }
+}
+</script>
+
+<style scoped>
+.input { @apply w-full border rounded px-2 py-1 outline-none focus:ring-2 focus:ring-blue-200; }
+.btn { @apply inline-flex items-center px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50; }
+</style>

--- a/frontend/server/api/projects/[slug]/index.delete.ts
+++ b/frontend/server/api/projects/[slug]/index.delete.ts
@@ -1,0 +1,40 @@
+import type { H3Event } from 'h3'
+import { djangoBase } from '~/server/utils/djangoBase'
+
+/**
+ * Server route (SSR) — Delete Project by slug
+ *
+ * DELETE /api/projects/[slug]
+ * → Proxies to: {DJANGO_BASE_URL}/api/v1/projects/:slug/
+ *
+ * Notes:
+ * - Forwards session cookies and CSRF header (if present) to support session-based auth during V1.
+ * - Normalizes upstream failures into a 502 without leaking backend internals.
+ */
+export default defineEventHandler(async (event: H3Event) => {
+  const base = djangoBase(event)
+
+  const { slug } = getRouterParams(event) as { slug?: string }
+  if (!slug) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing slug' })
+  }
+
+  // Forward only headers needed for session-based auth
+  const reqHeaders = getRequestHeaders(event) as Record<string, string | undefined>
+  const upstreamHeaders: Record<string, string> = {}
+  if (reqHeaders.cookie) upstreamHeaders.cookie = reqHeaders.cookie
+  if (reqHeaders['x-csrftoken']) upstreamHeaders['x-csrftoken'] = reqHeaders['x-csrftoken']
+
+  try {
+    await $fetch<void>(`${base}/api/v1/projects/${encodeURIComponent(slug)}/`, {
+      method: 'DELETE',
+      headers: upstreamHeaders,
+    })
+    return { ok: true }
+  } catch (e: any) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: `Proxy error (project delete): ${e?.message || String(e)}`,
+    })
+  }
+})

--- a/frontend/server/api/projects/[slug]/index.get.ts
+++ b/frontend/server/api/projects/[slug]/index.get.ts
@@ -1,0 +1,41 @@
+import type { H3Event } from 'h3'
+import type { ProjectResponse } from '~/shared/types/projects'
+import { djangoBase } from '~/server/utils/djangoBase'
+
+/**
+ * Server route (SSR) — Get Project detail by slug
+ *
+ * GET /api/projects/[slug]
+ * → Proxies to: {DJANGO_BASE_URL}/api/v1/projects/:slug/
+ *
+ * Notes:
+ * - Forwards session cookies and CSRF header (if present) to support session-based auth during V1.
+ * - Normalizes upstream failures into a 502 without leaking backend internals.
+ */
+export default defineEventHandler(async (event: H3Event): Promise<ProjectResponse> => {
+  const base = djangoBase(event)
+
+  const { slug } = getRouterParams(event) as { slug?: string }
+  if (!slug) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing slug' })
+  }
+
+  // Forward only headers needed for session-based auth
+  const reqHeaders = getRequestHeaders(event) as Record<string, string | undefined>
+  const upstreamHeaders: Record<string, string> = {}
+  if (reqHeaders.cookie) upstreamHeaders.cookie = reqHeaders.cookie
+  if (reqHeaders['x-csrftoken']) upstreamHeaders['x-csrftoken'] = reqHeaders['x-csrftoken']
+
+  try {
+    const data = await $fetch<ProjectResponse>(`${base}/api/v1/projects/${encodeURIComponent(slug)}/`, {
+      method: 'GET',
+      headers: upstreamHeaders,
+    })
+    return data
+  } catch (e: any) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: `Proxy error (project detail): ${e?.message || String(e)}`,
+    })
+  }
+})

--- a/frontend/server/api/projects/[slug]/index.patch.ts
+++ b/frontend/server/api/projects/[slug]/index.patch.ts
@@ -1,0 +1,48 @@
+import type { H3Event } from 'h3'
+import type { ProjectUpdateBody, ProjectResponse } from '~/shared/types/projects'
+import { djangoBase } from '~/server/utils/djangoBase'
+
+/**
+ * Server route (SSR) — Update Project by slug
+ *
+ * PATCH /api/projects/[slug]
+ * Body: Partial<ProjectUpdateBody>
+ * → Proxies to: {DJANGO_BASE_URL}/api/v1/projects/:slug/
+ *
+ * Notes:
+ * - Forwards session cookies and CSRF header (if present) to support session-based auth during V1.
+ * - Normalizes upstream failures into a 502 without leaking backend internals.
+ */
+export default defineEventHandler(async (event: H3Event): Promise<ProjectResponse> => {
+  const base = djangoBase(event)
+
+  const { slug } = getRouterParams(event) as { slug?: string }
+  if (!slug) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing slug' })
+  }
+
+  const body = (await readBody(event)) as Partial<ProjectUpdateBody> | null
+  if (!body || typeof body !== 'object') {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid body' })
+  }
+
+  // Forward only headers needed for session-based auth
+  const reqHeaders = getRequestHeaders(event) as Record<string, string | undefined>
+  const upstreamHeaders: Record<string, string> = { 'content-type': 'application/json' }
+  if (reqHeaders.cookie) upstreamHeaders.cookie = reqHeaders.cookie
+  if (reqHeaders['x-csrftoken']) upstreamHeaders['x-csrftoken'] = reqHeaders['x-csrftoken']
+
+  try {
+    const data = await $fetch<ProjectResponse>(`${base}/api/v1/projects/${encodeURIComponent(slug)}/`, {
+      method: 'PATCH',
+      headers: upstreamHeaders,
+      body,
+    })
+    return data
+  } catch (e: any) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: `Proxy error (project update): ${e?.message || String(e)}`,
+    })
+  }
+})

--- a/frontend/server/api/projects/index.post.ts
+++ b/frontend/server/api/projects/index.post.ts
@@ -1,0 +1,45 @@
+import type { H3Event } from 'h3'
+import type { ProjectCreateBody, ProjectResponse } from '~/shared/types/projects'
+import { djangoBase } from '~/server/utils/djangoBase'
+
+/**
+ * Server route (SSR) — Create Project
+ *
+ * POST /api/projects
+ * Body: { name: string, description?, status?, slug?, metadata? }
+ * → Proxied to: {DJANGO_BASE_URL}/api/v1/projects/
+ *
+ * Notes:
+ * - Forwards session cookies and CSRF header (if present) to support session-based auth during V1.
+ * - Does not leak backend internals; normalizes errors as Nitro errors.
+ */
+export default defineEventHandler(async (event: H3Event): Promise<ProjectResponse> => {
+  const base = djangoBase(event)
+
+  // Forward only required headers (session cookies and CSRF if present)
+  const reqHeaders = getRequestHeaders(event) as Record<string, string | undefined>
+  const upstreamHeaders: Record<string, string> = { 'content-type': 'application/json' }
+  if (reqHeaders.cookie) upstreamHeaders.cookie = reqHeaders.cookie
+  if (reqHeaders['x-csrftoken']) upstreamHeaders['x-csrftoken'] = reqHeaders['x-csrftoken']
+
+  // Basic validation (server-side) — backend performs strict validation as well
+  const body = (await readBody(event)) as Partial<ProjectCreateBody>
+  if (!body || typeof body.name !== 'string' || body.name.trim().length === 0) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing/invalid "name"' })
+  }
+
+  try {
+    const data = await $fetch<ProjectResponse>(`${base}/api/v1/projects/`, {
+      method: 'POST',
+      headers: upstreamHeaders,
+      body,
+    })
+    return data
+  } catch (e: any) {
+    // Normalize into a 502 to avoid leaking upstream internals
+    throw createError({
+      statusCode: 502,
+      statusMessage: `Proxy error (create project): ${e?.message || String(e)}`,
+    })
+  }
+})


### PR DESCRIPTION
Sortie du relax mode côté Web CI.\n- Suppression du flag continue-on-error dans le job web\n- Surveiller le run; si des erreurs lint/type/tests surgissent, on corrige rapidement.\n- Étape suivante après vert: retirer le flag côté API, puis revoir le job Security selon l’état des gates.